### PR TITLE
Bump resizer to 1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php" : "~7.2|~7.4",
-        "square1/resized": "~1.1.0"
+        "square1/resized": "~1.2.0"
     },
     "require-dev": {
         "laravel/framework": "~7.0",


### PR DESCRIPTION
Update to use https://github.com/square1-io/resized-php/releases/tag/v1.2.0 release.